### PR TITLE
colorize empty lines

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -5,6 +5,7 @@
 color_code_regex=$'(\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)[m|K])?'
 reset_color="\x1B\[m"
 dim_magenta="\x1B\[38;05;146m"
+invert_color="\x1B\[7m"
 
 format_diff_header () {
 	# simplify the unified patch diff header
@@ -29,5 +30,9 @@ print_horizontal_rule () {
 	printf "%$(tput cols)s\n"|sed 's/ /─/g'
 }
 
+colorize_empty_lines () {
+	sed -E "s/^($color_code_regex)[\+\-]($reset_color)\s*$/\1 $invert_color$(printf "%$(tput cols)s\n")\2/g"
+}
+
 # run it.
-cat $input | format_diff_header |  colorize_context_line | strip_leading_symbols
+cat $input | format_diff_header |  colorize_context_line | colorize_empty_lines | strip_leading_symbols


### PR DESCRIPTION
Due to hidden `+` and `-` it's impossible to see removed and added empty lines. This PR addresses this issue.

Before:
![before](https://cloud.githubusercontent.com/assets/717109/12920690/3f69ad00-cf52-11e5-84ee-fc929ca57780.png)

After:

![after](https://cloud.githubusercontent.com/assets/717109/12920694/43eb5d92-cf52-11e5-8d05-c4d7337df8fe.png)

 