### PR TITLE
use which to find our dependency

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -2,7 +2,7 @@
 
 [ $# -ge 1 -a -f "$1" ] && input="$1" || input="-"
 
-diff_highlight="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/third_party/diff-highlight/diff-highlight"
+diff_highlight=$(which diff-highlight)
 
 color_code_regex=$'(\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)[m|K])?'
 reset_color="\x1B\[m"


### PR DESCRIPTION
Note our `diff-highlight` is not the hard dependency. It's there for convience so the script is in $PATH. It's not possible to guarantee to know where exactly our `diff-highlight` is.

Fixes #6