### PR TITLE
Add git alias usage to docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,11 @@ git diff --color | diff-so-fancy
 git config --global core.pager "diff-so-fancy | less --tabs=1,5 -R"
 ```
 
+Or, create a git alias  in your `~/.gitconfig` for shorthand fanciness:
+```shell
+diff-so-fancy = "!git diff --color $@ | diff-so-fancy"
+```
+
 ## Install
 
 For convenience, the recommended installation is via NPM:


### PR DESCRIPTION
Thanks for `diff-so-fancy`. It's a great idea :+1:

This change adds a git alias definition for `diff-so-fancy` to the 'Usage' section of the README.

A git alias has the benefit of requiring less keystrokes than the piped series of commands each time, is tab-completed by git's default autocompletion, and leaves the default behaviour of `git diff` intact. 
