### PR TITLE
Define shorter `dsf` alias in docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ git config --global core.pager "diff-so-fancy | less --tabs=1,5 -R"
 
 Or, create a git alias  in your `~/.gitconfig` for shorthand fanciness:
 ```shell
-diff-so-fancy = "!git diff --color $@ | diff-so-fancy"
+dsf = "!git diff --color $@ | diff-so-fancy"
 ```
 
 ## Install


### PR DESCRIPTION
Shorten the docs git alias to `dsf` as per the discussion in: https://github.com/stevemao/diff-so-fancy/pull/30