### PR TITLE
Fixes path detection for nvm users

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -2,7 +2,7 @@
 
 [ $# -ge 1 -a -f "$1" ] && input="$1" || input="-"
 
-diff_highlight="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/third_party/diff-highlight/diff-highlight"
+diff_highlight="$( cd "$( dirname realpath "${BASH_SOURCE[0]}" )" && pwd )/third_party/diff-highlight/diff-highlight"
 
 color_code_regex=$'(\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)[m|K])?'
 reset_color="\x1B\[m"


### PR DESCRIPTION
nvm creates the symlinks:
  * ~/.nvm/versions/node/v5.5.0/bin/diff-so-fancy -> ~/.nvm/versions/node/v5.5.0/lib/node_modules/diff-so-fancy/diff-so-fancy
  * ~/.nvm/versions/node/v5.5.0/bin/diff-highlight -> ~/.nvm/versions/node/v5.5.0/lib/node_modules/diff-so-fancy/third_party/diff-highlight/diff-highlight

which was breaking the path detection.