### PR TITLE
Fix color code regex to match all bash color codes

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -4,7 +4,7 @@
 
 diff_highlight="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/third_party/diff-highlight/diff-highlight"
 
-color_code_regex=$'(\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)[m|K])?'
+color_code_regex=$'(\x1B\\[([0-9]{1,3}(;[0-9]{1,3})?(;[0-9]{1,3})?)[m|K])?'
 reset_color="\x1B\[m"
 dim_magenta="\x1B\[38;05;146m"
 
@@ -13,7 +13,7 @@ format_diff_header () {
 	sed -E "s/^($color_code_regex)diff --git .*$//g" | \
 	sed -E "s/^($color_code_regex)index .*$/\
 \1$(print_horizontal_rule)/g" | \
-	sed -E "s/^($color_code_regex)\+\+\+(.*)$/\1\+\+\+\5\\
+	sed -E "s/^($color_code_regex)\+\+\+(.*)$/\1\+\+\+\6\\
 \1$(print_horizontal_rule)/g"
 }
 

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -4,7 +4,7 @@
 
 diff_highlight="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/third_party/diff-highlight/diff-highlight"
 
-color_code_regex=$'(\x1B\\[([0-9]{1,3}(;[0-9]{1,3})?(;[0-9]{1,3})?)[m|K])?'
+color_code_regex=$'(\x1B\\[([0-9]{1,3}(;[0-9]{1,3}){0,3})[m|K])?'
 reset_color="\x1B\[m"
 dim_magenta="\x1B\[38;05;146m"
 


### PR DESCRIPTION
This was breaking default mercurial output which is `0;32;1`. Theoretically you could have more than three codes in the sequence, but I haven't seen that used.