### PR TITLE
Don't require index line to render correctly

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -8,11 +8,14 @@ color_code_regex=$'(\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)[m|K])?'
 reset_color="\x1B\[m"
 dim_magenta="\x1B\[38;05;146m"
 
+git_index_line_pattern="^($color_code_regex)index .*"
+
 format_diff_header () {
 	# simplify the unified patch diff header
 	sed -E "s/^($color_code_regex)diff --git .*$//g" | \
-	sed -E "s/^($color_code_regex)index .*$/\
-\1$(print_horizontal_rule)/g" | \
+	sed -E "/$git_index_line_pattern/{N;s/$git_index_line_pattern\n//}" | \
+	sed -E "s/^($color_code_regex)\-\-\-(.*)$/\1$(print_horizontal_rule)\\
+\-\-\-\5/g" |
 	sed -E "s/^($color_code_regex)\+\+\+(.*)$/\1\+\+\+\5\\
 \1$(print_horizontal_rule)/g"
 }

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -15,7 +15,7 @@ format_diff_header () {
 	sed -E "s/^($color_code_regex)diff --git .*$//g" | \
 	sed -E "/$git_index_line_pattern/{N;s/$git_index_line_pattern\n//}" | \
 	sed -E "s/^($color_code_regex)\-\-\-(.*)$/\1$(print_horizontal_rule)\\
-\-\-\-\5/g" |
+\1\-\-\-\5/g" |
 	sed -E "s/^($color_code_regex)\+\+\+(.*)$/\1\+\+\+\5\\
 \1$(print_horizontal_rule)/g"
 }


### PR DESCRIPTION
Mercurial doesn't output the `index a7f8d9e..3fa2821 100644` line, so this PR removes the line completely (that sed wouldn't work on two index lines after each other, but that's not gonna happen in the diff output) and prepends the horizontal rule tu the `---` file line instead.

It's a bit cryptic, so if you have a solution for mercurial, let me know, or if you don't care enough, don't merge it.

Needs careful merge with the other PR I put up (since the back reference numbers change in that one).
