### PR TITLE
Add `-F -X` flags to the pager so that less doesn't clear the screen for a short diff

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,8 +21,8 @@ git diff --color | diff-so-fancy
 
 **But**, you'll probably want to fancify all your diffs. Run this so `git diff` and `git show` will use it:
 ```shell
-git config --global pager.diff "diff-so-fancy | less --tabs=1,5 -R"
-git config --global pager.show "diff-so-fancy | less --tabs=1,5 -R"
+git config --global pager.diff "diff-so-fancy | less --tabs=1,5 -RFX"
+git config --global pager.show "diff-so-fancy | less --tabs=1,5 -RFX"
 ```
 
 Or, create a git alias  in your `~/.gitconfig` for shorthand fanciness:


### PR DESCRIPTION
`-F` makes less return immediately if the content fits on the screen. Without this you need to press Q to get back to your shell even if the diff was only a few lines long
`-X` prevent less from clearing the screen at the beginning. Which is undesirable if the content fits on one screen and unnecessary if the content is longer than a screen.

And the `-R` flag (not added by this PR) displays colors correctly instead of outputting as ASCII representation of the control chars