### PR TITLE
simplify realpath/bash_source logic

### DIFF
--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -2,6 +2,18 @@
 
 [ $# -ge 1 -a -f "$1" ] && input="$1" || input="-"
 
+
+# https://gist.github.com/TheMengzor/968e5ea87e99d9c41782
+get_script_dir () {
+	SOURCE="${BASH_SOURCE[0]}"
+	while [ -h "$SOURCE" ]; do
+	  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+	  SOURCE="$(readlink "$SOURCE")"
+	  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+	done
+	echo $( cd -P "$( dirname "$SOURCE" )" && pwd )
+}
+
 # find my sed
 hash gsed 2> /dev/null && SED=gsed || SED=sed
 
@@ -9,8 +21,7 @@ hash gsed 2> /dev/null && SED=gsed || SED=sed
 if hash diff-highlight 2> /dev/null; then
 	diff_highlight=diff-highlight
 else
-	SCRIPT_PATH=$( cd $(dirname $0) ; pwd -P )
-	diff_highlight="$SCRIPT_PATH/third_party/diff-highlight/diff-highlight"
+	diff_highlight="$(get_script_dir)/third_party/diff-highlight/diff-highlight"
 fi
 
 color_code_regex="(\x1B\[([0-9]{1,3}(;[0-9]{1,3}){0,3})[m|K])?"

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -2,8 +2,6 @@
 
 [ $# -ge 1 -a -f "$1" ] && input="$1" || input="-"
 
-
-# https://gist.github.com/TheMengzor/968e5ea87e99d9c41782
 get_script_dir () {
 	src="${BASH_SOURCE[0]}"
 	while [ -h "$src" ]; do

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -9,7 +9,8 @@ hash gsed 2> /dev/null && SED=gsed || SED=sed
 if hash diff-highlight 2> /dev/null; then
 	diff_highlight=diff-highlight
 else
-	diff_highlight="$( cd "$( dirname $(realpath "${BASH_SOURCE[0]}") )" && pwd )/third_party/diff-highlight/diff-highlight"
+	SCRIPT_PATH=$( cd $(dirname $0) ; pwd -P )
+	diff_highlight="$SCRIPT_PATH/third_party/diff-highlight/diff-highlight"
 fi
 
 color_code_regex="(\x1B\[([0-9]{1,3}(;[0-9]{1,3}){0,3})[m|K])?"

--- a/diff-so-fancy
+++ b/diff-so-fancy
@@ -5,13 +5,13 @@
 
 # https://gist.github.com/TheMengzor/968e5ea87e99d9c41782
 get_script_dir () {
-	SOURCE="${BASH_SOURCE[0]}"
-	while [ -h "$SOURCE" ]; do
-	  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-	  SOURCE="$(readlink "$SOURCE")"
-	  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+	src="${BASH_SOURCE[0]}"
+	while [ -h "$src" ]; do
+	  dir="$( cd -P "$( dirname "$src" )" && pwd )"
+	  src="$(readlink "$src")"
+	  [[ $src != /* ]] && src="$dir/$src"
 	done
-	echo $( cd -P "$( dirname "$SOURCE" )" && pwd )
+	echo $( cd -P "$( dirname "$src" )" && pwd )
 }
 
 # find my sed


### PR DESCRIPTION
Realpath isn't present on a lot of systems and I believe would necessitate extra dependencies.

The included technique is courtesy of https://gist.github.com/TheMengzor/968e5ea87e99d9c41782 and works well in my tests.